### PR TITLE
Includes a traffic model check

### DIFF
--- a/R/mp_matrix.R
+++ b/R/mp_matrix.R
@@ -58,6 +58,7 @@ mp_matrix = function(
   # Checks
   mode = match.arg(mode)
   avoid = match.arg(avoid)
+  traffic_model = match.arg(traffic_model)
   .check_posix_time(arrival_time)
   .check_posix_time(departure_time)
 


### PR DESCRIPTION
When departure time is specified and traffic model is missing, the mp_matrix function returns an error related to the length of the string.