### PR TITLE
Adds transit arguments in the Directions API

### DIFF
--- a/R/mp_directions.R
+++ b/R/mp_directions.R
@@ -19,6 +19,8 @@
 #' @param avoid \code{NA} (default, means avoid nothing) or one of: \code{"tolls"}, \code{"highways"}, \code{"ferries"} or \code{"indoor"}
 #' @param region The region code, specified as a ccTLD ("top-level domain") two-character value (e.g. \code{"es"} for Spain) (optional)
 #' @param traffic_model The traffic model, one of: \code{"best_guess"} (the default), \code{"pessimistic"}, \code{"optimistic"}. The \code{traffic_model} parameter is only taken into account when \code{departure_time} is specified!
+#' @param transit_mode Transit preferred mode, one or more of: \code{"bus"}, \code{"subway"}, \code{"train"} or \code{"tram"}
+#' @param transit_routing_preference Transit route preference. \code{NA} (default, means no preference) or one of: \code{"less_walking"} or \code{"fewer_transfers"}
 #' @param key Google APIs key
 #' @param quiet Logical; suppress printing URL for Google Maps API call (e.g. to hide API key)
 #' @return XML document with Google Maps Directions API response
@@ -95,6 +97,8 @@ mp_directions = function(
   avoid = c(NA, "tolls", "highways", "ferries", "indoor"),
   region = NULL,
   traffic_model = c("best_guess", "pessimistic", "optimistic"),
+  transit_mode = c ("bus", "subway", "train", "tram"),
+  transit_routing_preference = c(NA, "less_walking", "fewer_transfers"),
   key,
   quiet = FALSE
   ) {
@@ -103,6 +107,8 @@ mp_directions = function(
   mode = match.arg(mode)
   avoid = match.arg(avoid)
   traffic_model = match.arg(traffic_model)
+  transit_mode = match.arg(transit_mode,several.ok = TRUE)
+  transit_routing_preference = match.arg(transit_routing_preference)
   .check_posix_time(arrival_time)
   .check_posix_time(departure_time)
 
@@ -178,6 +184,24 @@ mp_directions = function(
     )
   }
 
+  # Add 'transit_mode'
+  if(mode == "transit") {
+    url = paste0(
+      url,
+      "&transit_mode=",
+      paste0(transit_mode,collapse = "|")
+    )
+
+    # Add 'transit_routing_preference'
+    if(!is.na(transit_routing_preference)) {
+      url = paste0(
+        url,
+        "&transit_routing_preference=",
+        transit_routing_preference
+      )
+    }
+  }
+  
   # Add key
   if(!is.null(key)) {
     url = paste0(


### PR DESCRIPTION
Hi!

The additional arguments that only apply for Transit were missing. Two more arguments were included to support them. Descriptions for the documentation and checks were also added.

Based on [this](https://developers.google.com/maps/documentation/directions/get-directions#optional-parameters)


By the way, thanks for this awesome package! 💯 
