### PR TITLE
Styles for static maps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     stars,
     RgoogleMaps,
     httr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Suggests: 
     knitr,
     rmarkdown,

--- a/R/check_inputs.R
+++ b/R/check_inputs.R
@@ -62,3 +62,11 @@
   if(!zoom %% 1 == 0) stop("'zoom' must be an integer")
   if(zoom < 0) stop("'zoom' must be positive")
 }
+
+## Map styles
+
+.check_map_style = function(style) {
+  valid = inherits(style, 'list') && all(sapply(style, \(x) inherits(x, 'character')))
+  if (!valid) stop("'style' should be a list of named character vectors")
+}
+

--- a/R/check_inputs.R
+++ b/R/check_inputs.R
@@ -60,10 +60,18 @@
 
 .check_map_zoom = function(zoom) {
   if(!zoom %% 1 == 0) stop("'zoom' must be an integer")
-  if(zoom < 0) stop("'zoom' must be positive")
+  if(!(zoom >= 0 && zoom <= 21)) stop("'zoom' must be within 0 and 21")
 }
 
-## Map styles
+.check_map_size = function (size) {
+  if(any(is.na(as.integer(size)))) stop("'size' must be an integer or coercible to one")
+  if(!length(size) == 2) stop("'size' must be of length 2")
+  if(!all(0 < size & size <= 640)) stop("'size' must be within 0 and 640")
+}
+
+.check_map_scale = function (scale) {
+  if(!scale %in% 1:2) stop("'scale' must be either 1 or 2")
+}
 
 .check_map_style = function(style) {
   valid = inherits(style, 'list') && all(sapply(style, \(x) inherits(x, 'character')))

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,0 +1,9 @@
+## Process map styles
+
+.styles_to_url = function (style) {
+  .check_map_style(style)
+  style |>
+    lapply(\(x) paste(names(x), x, sep = ':')) |>
+    sapply(\(x) paste0(x, collapse = '|')) |>
+    paste0(collapse = '&style=')
+}   

--- a/R/mp_map.R
+++ b/R/mp_map.R
@@ -7,6 +7,10 @@
 #' @param maptype Map type, one of: \code{"roadmap"}, \code{"satellite"}, \code{"terrain"}, \code{"hybrid"}.
 #' @param key Google APIs key
 #' @param quiet Logical; suppress printing URL for Google Maps API call (e.g. to hide API key)
+#' @param style List of named character vector(s) specifying style directives.
+#' The full style reference is available at
+#' https://developers.google.com/maps/documentation/maps-static/style-reference,
+#' see examples below.
 #' @return A \code{stars} raster with the requested map, in Web Mercator CRS (EPSG:3857).
 #' @references \url{https://developers.google.com/maps/documentation/maps-static/overview}
 #' @export
@@ -89,6 +93,18 @@
 #'   theme1
 #' g1 + g2 + g3 + g4
 #'
+#' # styled maps
+#' nl = list(
+#'   c(feature = 'all', element = 'labels', visibility = 'off')
+#' )
+#' nb = list(
+#'   c(feature = 'poi.business', visibility = 'off'),
+#'   c(feature = 'poi.medical', visibility = 'off')
+#' )
+#' r_nl = mp_map(pnt, 14, key = key, style = nl)
+#' plot(r_nl)
+#' r_nb = mp_map(pnt, 14, key = key, style = nb)
+#' plot(r_nb)
 #' }
 
 mp_map = function(
@@ -96,6 +112,7 @@ mp_map = function(
   zoom,
   maptype = c("roadmap", "satellite", "terrain", "hybrid"),
   key,
+  style = NULL,
   quiet = FALSE
 ) {
 
@@ -134,6 +151,16 @@ mp_map = function(
     "&maptype=",
     maptype
   )
+  
+  # Add style
+  if (!is.null(style)) {
+    style = .styles_to_url(style)
+    url = paste0(
+      url,
+      '&style=',
+      style
+    )
+  }
 
   # Add key
   if(!is.null(key)) {

--- a/man/mp_map.Rd
+++ b/man/mp_map.Rd
@@ -6,8 +6,11 @@
 \usage{
 mp_map(
   center,
-  zoom,
+  zoom = 10L,
   maptype = c("roadmap", "satellite", "terrain", "hybrid"),
+  size = c(640L, 640L),
+  scale = 2L,
+  style = NULL,
   key,
   quiet = FALSE
 )
@@ -15,9 +18,22 @@ mp_map(
 \arguments{
 \item{center}{Character of length 1 of the form \code{"lat,lon"} or a geometry of class \code{sfg}, \code{sfc} or \code{sf}. If \code{center} is a geometry, the center of the geometry bounding box is passed as map center. Missing Coordinate Reference System (CRS) is assumed WGS84.}
 
-\item{zoom}{Zoom level, a positive integer or zero. The appropriate range is \code{0} to \code{20}.}
+\item{zoom}{Zoom level, a positive integer or zero. The appropriate range is
+\code{0} to \code{21}. Defaults to `10`.}
 
 \item{maptype}{Map type, one of: \code{"roadmap"}, \code{"satellite"}, \code{"terrain"}, \code{"hybrid"}.}
+
+\item{size}{Numeric of length 2, the width and height of the map in pixels.
+The default is the maximum size allowed (640x640). The final dimensions of
+the image are affected by `scale`.}
+
+\item{scale}{Integer, factor to multiply `size` and determine the final image
+size. Allowed values are 1 and 2, defaults to 2.}
+
+\item{style}{List of named character vector(s) specifying style directives.
+The full style reference is available at
+https://developers.google.com/maps/documentation/maps-static/style-reference,
+see examples below.}
 
 \item{key}{Google APIs key}
 
@@ -108,6 +124,18 @@ g4 = ggplot() +
   theme1
 g1 + g2 + g3 + g4
 
+# styled maps
+nl = list(
+  c(feature = 'all', element = 'labels', visibility = 'off')
+)
+nb = list(
+  c(feature = 'poi.business', visibility = 'off'),
+  c(feature = 'poi.medical', visibility = 'off')
+)
+r_nl = mp_map(pnt, 14, key = key, style = nl)
+plot(r_nl)
+r_nb = mp_map(pnt, 14, key = key, style = nb)
+plot(r_nb)
 }
 }
 \references{


### PR DESCRIPTION
- added styles for static maps
- added styles for static maps

Added styles as part of the url building in `mp_map`. This allows to use the
powerful styles directives from the maps API to either change the look completely
or get basemaps with less clutter. Also added a couple of examples for the docs
and a file `helpers.R` with a mini function to help processing the styles without
cluttering the main code.
